### PR TITLE
Add training scripts and inference for AE, diffusion, shape completio…

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,492 @@
+"""
+Main training script for the Voxelized Diffusion model (Diffusion-SDF).
+
+Trains the text-conditioned 3D diffusion model using PyTorch Lightning.
+The autoencoder (AE) must be pre-trained first using train_ae.py.
+
+Usage:
+    python main.py --config configs/voxdiff-uinu.yaml
+
+    # Resume from checkpoint:
+    python main.py --config configs/voxdiff-uinu.yaml --resume /path/to/checkpoint.ckpt
+
+    # Multi-GPU:
+    python main.py --config configs/voxdiff-uinu.yaml --gpus 0,1,2,3
+"""
+
+import argparse
+import datetime
+import os
+import signal
+import sys
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+from omegaconf import OmegaConf
+from pytorch_lightning import seed_everything
+from pytorch_lightning.callbacks import (
+    Callback,
+    LearningRateMonitor,
+    ModelCheckpoint,
+)
+from pytorch_lightning.trainer import Trainer
+from pytorch_lightning.utilities.distributed import rank_zero_only
+from torch.utils.data import DataLoader, Dataset
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Utility
+# ─────────────────────────────────────────────────────────────────────────────
+
+def get_obj_from_str(string, reload=False):
+    """Instantiate a class or function from a dotted string."""
+    module, cls = string.rsplit('.', 1)
+    if reload:
+        import importlib
+        module_imp = importlib.import_module(module)
+        importlib.reload(module_imp)
+    return getattr(__import__(module, fromlist=[cls]), cls)
+
+
+def instantiate_from_config(config):
+    if 'target' not in config:
+        if config == '__is_first_stage__':
+            return None
+        if config == '__is_unconditional__':
+            return None
+        raise KeyError('Expected key "target" to instantiate.')
+    return get_obj_from_str(config['target'])(**config.get('params', {}))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data Module
+# ─────────────────────────────────────────────────────────────────────────────
+
+class WrappedDataset(Dataset):
+    """Wraps an arbitrary mapping to be compatible with DataLoader."""
+
+    def __init__(self, dataset):
+        self.data = dataset
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
+class DataModuleFromConfig(pl.LightningDataModule):
+    """
+    LightningDataModule that instantiates train/val/test datasets from config.
+
+    Expected config format:
+        data:
+          target: main.DataModuleFromConfig
+          params:
+            batch_size: 48
+            num_workers: 5
+            train:
+              target: models.voxdiff.data.snet.ShapeNetTextDatasetTrain
+              params: {thres: 0.2, ucond_p: 0.2, cat: all}
+            validation:
+              target: models.voxdiff.data.snet.ShapeNetTextDatasetValidation
+              params: {thres: 0.2, cat: all}
+    """
+
+    def __init__(
+        self,
+        batch_size: int,
+        train=None,
+        validation=None,
+        test=None,
+        predict=None,
+        wrap: bool = False,
+        num_workers: int = None,
+        shuffle_test_loader: bool = False,
+        use_worker_init_fn: bool = False,
+        shuffle_val_dataloader: bool = False,
+    ):
+        super().__init__()
+        self.batch_size = batch_size
+        self.dataset_configs = {}
+        self.num_workers = num_workers if num_workers is not None else batch_size * 2
+        self.use_worker_init_fn = use_worker_init_fn
+
+        if train is not None:
+            self.dataset_configs['train'] = train
+        if validation is not None:
+            self.dataset_configs['validation'] = validation
+        if test is not None:
+            self.dataset_configs['test'] = test
+        if predict is not None:
+            self.dataset_configs['predict'] = predict
+
+        self.wrap = wrap
+        self.shuffle_test_loader = shuffle_test_loader
+        self.shuffle_val_dataloader = shuffle_val_dataloader
+
+    def prepare_data(self):
+        for cfg in self.dataset_configs.values():
+            instantiate_from_config(cfg)
+
+    def setup(self, stage=None):
+        self.datasets = {}
+        for k, cfg in self.dataset_configs.items():
+            self.datasets[k] = instantiate_from_config(cfg)
+            if self.wrap:
+                self.datasets[k] = WrappedDataset(self.datasets[k])
+
+    def _make_loader(self, split, shuffle=False):
+        dataset = self.datasets[split]
+        is_iterable = isinstance(dataset, torch.utils.data.IterableDataset)
+        return DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            shuffle=False if is_iterable else shuffle,
+            pin_memory=True,
+        )
+
+    def train_dataloader(self):
+        return self._make_loader('train', shuffle=True)
+
+    def val_dataloader(self):
+        return self._make_loader('validation', shuffle=self.shuffle_val_dataloader)
+
+    def test_dataloader(self):
+        return self._make_loader('test', shuffle=self.shuffle_test_loader)
+
+    def predict_dataloader(self):
+        return self._make_loader('predict', shuffle=False)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Callbacks
+# ─────────────────────────────────────────────────────────────────────────────
+
+class SetupCallback(Callback):
+    """Create output directories and save configs before training starts."""
+
+    def __init__(self, resume, now, logdir, ckptdir, cfgdir, config, lightning_config):
+        super().__init__()
+        self.resume = resume
+        self.now = now
+        self.logdir = logdir
+        self.ckptdir = ckptdir
+        self.cfgdir = cfgdir
+        self.config = config
+        self.lightning_config = lightning_config
+
+    def on_keyboard_interrupt(self, trainer, pl_module):
+        if trainer.global_rank == 0:
+            print('Received KeyboardInterrupt signal; attempting to create checkpoint ...')
+            ckpt_path = os.path.join(self.ckptdir, 'last.ckpt')
+            trainer.save_checkpoint(ckpt_path)
+
+    def on_pretrain_routine_start(self, trainer, pl_module):
+        if trainer.global_rank == 0:
+            os.makedirs(self.logdir, exist_ok=True)
+            os.makedirs(self.ckptdir, exist_ok=True)
+            os.makedirs(self.cfgdir, exist_ok=True)
+
+            OmegaConf.save(self.config,
+                           os.path.join(self.cfgdir, f'{self.now}-project.yaml'))
+            OmegaConf.save(OmegaConf.create({'lightning': self.lightning_config}),
+                           os.path.join(self.cfgdir, f'{self.now}-lightning.yaml'))
+
+
+class ImageLogger(Callback):
+    """Periodically log reconstructed and generated shape renderings."""
+
+    def __init__(self, batch_frequency=2000, max_images=4, clamp=True,
+                 increase_log_steps=True, rescale=True, disabled=False,
+                 log_on_batch_idx=False, log_first_step=False, log_images_kwargs=None):
+        super().__init__()
+        self.rescale = rescale
+        self.batch_freq = batch_frequency
+        self.max_images = max_images
+        self.log_steps = [2 ** n for n in range(int(np.log2(self.batch_freq)) + 1)]
+        if not increase_log_steps:
+            self.log_steps = [self.batch_freq]
+        self.clamp = clamp
+        self.disabled = disabled
+        self.log_on_batch_idx = log_on_batch_idx
+        self.log_images_kwargs = log_images_kwargs if log_images_kwargs else {}
+        self.log_first_step = log_first_step
+
+    @rank_zero_only
+    def log_local(self, save_dir, split, images, global_step, current_epoch, batch_idx):
+        import torchvision
+        root = os.path.join(save_dir, 'images', split)
+        os.makedirs(root, exist_ok=True)
+        for k in images:
+            grid = torchvision.utils.make_grid(images[k], nrow=4)
+            if self.rescale:
+                grid = (grid + 1.0) / 2.0  # [-1,1] -> [0,1]
+            grid = grid.permute(1, 2, 0)  # H W C
+            grid_np = (grid.numpy() * 255).clip(0, 255).astype(np.uint8)
+            filename = f'{k}_gs-{global_step:06d}_e-{current_epoch:06d}_b-{batch_idx:06d}.png'
+            import PIL.Image
+            PIL.Image.fromarray(grid_np).save(os.path.join(root, filename))
+
+    def log_img(self, pl_module, batch, batch_idx, split='train'):
+        check_idx = batch_idx if self.log_on_batch_idx else pl_module.global_step
+        if (self.check_frequency(check_idx) and
+                hasattr(pl_module, 'log_images') and
+                callable(pl_module.log_images) and
+                self.max_images > 0):
+            logger = type(pl_module.logger)
+            is_train = pl_module.training
+            if is_train:
+                pl_module.eval()
+            with torch.no_grad():
+                images = pl_module.log_images(
+                    batch,
+                    split=split,
+                    **self.log_images_kwargs,
+                )
+            for k in images:
+                N = min(images[k].shape[0], self.max_images)
+                images[k] = images[k][:N]
+                if isinstance(images[k], torch.Tensor):
+                    images[k] = images[k].detach().cpu()
+                    if self.clamp:
+                        images[k] = torch.clamp(images[k], -1., 1.)
+            self.log_local(
+                pl_module.logger.save_dir,
+                split, images,
+                pl_module.global_step,
+                pl_module.current_epoch,
+                batch_idx,
+            )
+            if is_train:
+                pl_module.train()
+
+    def check_frequency(self, check_idx):
+        if ((check_idx % self.batch_freq) == 0 or
+                (check_idx in self.log_steps)) and (check_idx > 0 or self.log_first_step):
+            return True
+        return False
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0):
+        if not self.disabled and (pl_module.global_step > 0 or self.log_first_step):
+            self.log_img(pl_module, batch, batch_idx, split='train')
+
+    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0):
+        if not self.disabled and pl_module.global_step > 0:
+            self.log_img(pl_module, batch, batch_idx, split='val')
+        if hasattr(pl_module, 'calibrate_grad_norm'):
+            if (pl_module.calibrate_grad_norm and batch_idx % 25 == 0) and batch_idx > 0:
+                self.log_grad_norm(trainer, pl_module, batch, batch_idx)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Argument Parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+def get_parser(**parser_kwargs):
+    parser = argparse.ArgumentParser(**parser_kwargs)
+    parser.add_argument(
+        '-c', '--config',
+        nargs='*',
+        metavar='config.yaml',
+        help='paths to base configs. Loaded from left-to-right. '
+             'Parameters can be overwritten or added with command-line options of the form `--key value`.',
+        default=['configs/voxdiff-uinu.yaml'],
+    )
+    parser.add_argument(
+        '-r', '--resume',
+        type=str,
+        const=True,
+        default='',
+        nargs='?',
+        help='resume from logdir or checkpoint in logdir',
+    )
+    parser.add_argument(
+        '-l', '--logdir',
+        type=str,
+        default='logs',
+        help='directory for logging',
+    )
+    parser.add_argument(
+        '-s', '--seed',
+        type=int,
+        default=23,
+        help='seed for seed_everything',
+    )
+    parser.add_argument(
+        '-f', '--postfix',
+        type=str,
+        default='',
+        help='post-postfix for default name',
+    )
+    parser.add_argument(
+        '-n', '--name',
+        type=str,
+        const=True,
+        default='',
+        nargs='?',
+        help='postfix for logdir',
+    )
+    parser.add_argument(
+        '--no_test',
+        action='store_true',
+        default=False,
+        help='disable test',
+    )
+    parser.add_argument(
+        '--gpus',
+        type=str,
+        default='0',
+        help='gpu ids to use, e.g. "0,1,2"',
+    )
+    parser.add_argument(
+        '--max_epochs',
+        type=int,
+        default=500,
+        help='maximum number of training epochs',
+    )
+    parser.add_argument(
+        '--scale_lr',
+        action='store_true',
+        default=False,
+        help='scale base-lr by ngpu * batch_size * n_accumulate',
+    )
+    return parser
+
+
+def nondefault_trainer_args(opt):
+    parser = argparse.ArgumentParser()
+    parser = Trainer.add_argparse_args(parser)
+    args = parser.parse_args([])
+    return sorted(k for k in vars(args) if getattr(opt, k) != getattr(args, k))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+if __name__ == '__main__':
+    now = datetime.datetime.now().strftime('%Y-%m-%dT%H-%M-%S')
+
+    # ── parse arguments ──────────────────────────────────────────────────────
+    parser = get_parser()
+    parser = Trainer.add_argparse_args(parser)
+    opt, unknown = parser.parse_known_args()
+
+    # ── seed ─────────────────────────────────────────────────────────────────
+    seed_everything(opt.seed)
+
+    # ── load configs ─────────────────────────────────────────────────────────
+    configs = [OmegaConf.load(c) for c in opt.config]
+    cli = OmegaConf.from_dotlist(unknown)
+    config = OmegaConf.merge(*configs, cli)
+    lightning_config = config.pop('lightning', OmegaConf.create())
+    trainer_config = lightning_config.get('trainer', OmegaConf.create())
+
+    # ── resolve GPU configuration ─────────────────────────────────────────────
+    gpu_ids = [int(g) for g in str(opt.gpus).split(',')]
+    n_gpus = len(gpu_ids)
+    if n_gpus > 1:
+        trainer_config['accelerator'] = 'gpu'
+        trainer_config['devices'] = gpu_ids
+        trainer_config['strategy'] = 'ddp'
+    else:
+        trainer_config['accelerator'] = 'gpu'
+        trainer_config['devices'] = gpu_ids
+
+    # ── logging directory ─────────────────────────────────────────────────────
+    if opt.name:
+        name = opt.name
+    elif opt.resume:
+        name = opt.resume.split('/')[-1].split('.')[0]
+    else:
+        cfg_name = '-'.join(os.path.splitext(os.path.basename(c))[0]
+                            for c in opt.config)
+        name = cfg_name
+    if opt.postfix:
+        name = f'{name}_{opt.postfix}'
+
+    nowname = f'{now}_{name}'
+    logdir = os.path.join(opt.logdir, nowname)
+    ckptdir = os.path.join(logdir, 'checkpoints')
+    cfgdir = os.path.join(logdir, 'configs')
+
+    # ── resume ────────────────────────────────────────────────────────────────
+    ckpt_path = None
+    if opt.resume:
+        if not os.path.exists(opt.resume):
+            raise ValueError(f'Cannot find {opt.resume}')
+        if os.path.isfile(opt.resume):
+            ckpt_path = opt.resume
+            logdir = '/'.join(opt.resume.split('/')[:-2])
+        else:
+            # Directory: find latest checkpoint
+            ckptdir = os.path.join(opt.resume, 'checkpoints')
+            ckpt_path = os.path.join(ckptdir, 'last.ckpt')
+
+    # ── scale learning rate ───────────────────────────────────────────────────
+    base_lr = config.model.base_learning_rate
+    if opt.scale_lr:
+        bs = config.data.params.batch_size
+        accumulate = trainer_config.get('accumulate_grad_batches', 1)
+        lr = accumulate * n_gpus * bs * base_lr
+        print(f'Setting learning rate to {lr:.2e} = '
+              f'{accumulate} (accumulate) × {n_gpus} (GPUs) × '
+              f'{bs} (bs) × {base_lr:.2e} (base_lr)')
+        config.model.base_learning_rate = lr
+    else:
+        lr = base_lr
+        print(f'Learning rate: {lr:.2e}')
+
+    # ── instantiate model ─────────────────────────────────────────────────────
+    model = instantiate_from_config(config.model)
+
+    # ── instantiate data module ───────────────────────────────────────────────
+    data = instantiate_from_config(config.data)
+    data.prepare_data()
+    data.setup()
+
+    # ── callbacks ─────────────────────────────────────────────────────────────
+    callbacks = [
+        SetupCallback(
+            resume=opt.resume,
+            now=now,
+            logdir=logdir,
+            ckptdir=ckptdir,
+            cfgdir=cfgdir,
+            config=config,
+            lightning_config=lightning_config,
+        ),
+        ModelCheckpoint(
+            dirpath=ckptdir,
+            filename='{epoch:06d}',
+            verbose=True,
+            save_last=True,
+            every_n_epochs=10,
+        ),
+        LearningRateMonitor(logging_interval='step'),
+        ImageLogger(
+            batch_frequency=2000,
+            max_images=4,
+            clamp=True,
+        ),
+    ]
+
+    # ── trainer ───────────────────────────────────────────────────────────────
+    trainer_kwargs = dict(trainer_config)
+    trainer_kwargs['max_epochs'] = opt.max_epochs
+    trainer_kwargs['callbacks'] = callbacks
+    trainer_kwargs['default_root_dir'] = logdir
+
+    trainer = Trainer(**trainer_kwargs)
+
+    # ── train ─────────────────────────────────────────────────────────────────
+    try:
+        trainer.fit(model, data, ckpt_path=ckpt_path)
+    except Exception as e:
+        # Save emergency checkpoint
+        emergency_ckpt = os.path.join(ckptdir, 'emergency.ckpt')
+        trainer.save_checkpoint(emergency_ckpt)
+        raise e

--- a/models/voxdiff/data/snet.py
+++ b/models/voxdiff/data/snet.py
@@ -1,0 +1,284 @@
+"""
+ShapeNet SDF + Text Dataset for Diffusion-SDF training.
+
+Expected data directory structure:
+    data/
+        ShapeNet/
+            sdf/
+                <category_id>/
+                    <model_id>/
+                        pc_sdf_sample.h5    # float32 SDF, shape (64,64,64)
+            text/
+                captions.json               # {model_id: [caption1, caption2, ...]}
+
+The captions.json can be sourced from Text2Shape or ShapeGlot datasets.
+"""
+
+import os
+import json
+import random
+import h5py
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+# Default ShapeNet category IDs (13 common categories)
+SHAPENET_CAT_IDS = {
+    'chair':    '03001627',
+    'table':    '04379243',
+    'airplane': '02691156',
+    'car':      '02958343',
+    'sofa':     '04256520',
+    'lamp':     '03636649',
+    'cabinet':  '02933112',
+    'monitor':  '03211117',
+    'gun':      '04090263',
+    'couch':    '04401088',
+    'vessel':   '04530566',
+    'speaker':  '03691459',
+    'telephone':'04401088',
+}
+
+ALL_CATS = list(SHAPENET_CAT_IDS.values())
+
+
+def load_sdf(h5_path):
+    """Load SDF from h5 file. Returns tensor (1, 64, 64, 64)."""
+    with h5py.File(h5_path, 'r') as f:
+        # Support different key names
+        if 'pc_sdf_sample' in f:
+            sdf = f['pc_sdf_sample'][:].astype(np.float32)
+        elif 'sdf' in f:
+            sdf = f['sdf'][:].astype(np.float32)
+        else:
+            key = list(f.keys())[0]
+            sdf = f[key][:].astype(np.float32)
+    sdf = torch.from_numpy(sdf).view(1, 64, 64, 64)
+    return sdf
+
+
+class ShapeNetTextDatasetBase(Dataset):
+    """
+    Base ShapeNet dataset that provides voxelized SDF and text captions.
+
+    Args:
+        data_root:  path to the data directory containing 'sdf/' and 'text/'
+        split:      'train' or 'val'
+        cat:        category name (from SHAPENET_CAT_IDS), or 'all'
+        thres:      SDF clamp threshold (clip SDF to [-thres, thres])
+        ucond_p:    probability of returning empty string (unconditional training)
+        prompt:     if set, always use this text (useful for debugging)
+    """
+
+    def __init__(
+        self,
+        data_root: str = 'data/ShapeNet',
+        split: str = 'train',
+        cat: str = 'all',
+        thres: float = 0.2,
+        ucond_p: float = 0.0,
+        prompt: str = '',
+    ):
+        super().__init__()
+        self.data_root = data_root
+        self.split = split
+        self.thres = thres
+        self.ucond_p = ucond_p
+        self.prompt = prompt
+
+        # Determine categories
+        if cat == 'all':
+            self.cat_ids = ALL_CATS
+        elif cat in SHAPENET_CAT_IDS:
+            self.cat_ids = [SHAPENET_CAT_IDS[cat]]
+        else:
+            # Treat as raw category ID
+            self.cat_ids = [cat]
+
+        # Load captions
+        caption_path = os.path.join(data_root, 'text', 'captions.json')
+        if os.path.exists(caption_path):
+            with open(caption_path, 'r') as f:
+                self.captions = json.load(f)
+        else:
+            # Fallback: no captions available, use empty strings
+            self.captions = {}
+
+        # Collect all SDF samples
+        self.samples = self._collect_samples()
+
+    def _collect_samples(self):
+        """Collect (sdf_path, model_id) for all available models."""
+        samples = []
+        sdf_root = os.path.join(self.data_root, 'sdf')
+
+        # Load train/val split if available
+        split_file = os.path.join(self.data_root, f'{self.split}_models.json')
+        if os.path.exists(split_file):
+            with open(split_file, 'r') as f:
+                split_ids = set(json.load(f))
+        else:
+            split_ids = None
+
+        for cat_id in self.cat_ids:
+            cat_dir = os.path.join(sdf_root, cat_id)
+            if not os.path.isdir(cat_dir):
+                continue
+
+            for model_id in sorted(os.listdir(cat_dir)):
+                # Apply split filtering
+                if split_ids is not None:
+                    if model_id not in split_ids:
+                        continue
+
+                sdf_path = os.path.join(cat_dir, model_id, 'pc_sdf_sample.h5')
+                if not os.path.exists(sdf_path):
+                    # Try alternative filenames
+                    for fname in ['sdf.h5', 'model.h5']:
+                        alt = os.path.join(cat_dir, model_id, fname)
+                        if os.path.exists(alt):
+                            sdf_path = alt
+                            break
+                    else:
+                        continue
+
+                samples.append((sdf_path, model_id))
+
+        return samples
+
+    def __len__(self):
+        return len(self.samples)
+
+    def _get_caption(self, model_id):
+        """Return a text caption for the given model."""
+        if self.prompt:
+            return self.prompt
+
+        if model_id in self.captions:
+            caps = self.captions[model_id]
+            if isinstance(caps, list) and len(caps) > 0:
+                return random.choice(caps)
+            return str(caps)
+
+        return ''
+
+    def __getitem__(self, idx):
+        sdf_path, model_id = self.samples[idx]
+
+        # Load and preprocess SDF
+        sdf = load_sdf(sdf_path)  # (1, 64, 64, 64)
+
+        # Clamp SDF to [-thres, thres] and normalize to roughly [-1, 1]
+        if self.thres > 0:
+            sdf = torch.clamp(sdf, -self.thres, self.thres)
+            sdf = sdf / self.thres  # normalize to [-1, 1]
+
+        # Get text caption
+        caption = self._get_caption(model_id)
+
+        # Randomly drop caption for unconditional training (classifier-free guidance)
+        if self.ucond_p > 0 and random.random() < self.ucond_p:
+            caption = ''
+
+        return {
+            'sdf': sdf,          # float32 tensor (1, 64, 64, 64)
+            'caption': caption,  # str
+            'model_id': model_id,
+        }
+
+
+class ShapeNetTextDatasetTrain(ShapeNetTextDatasetBase):
+    """Training split of ShapeNet SDF + text dataset."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault('split', 'train')
+        super().__init__(**kwargs)
+
+
+class ShapeNetTextDatasetValidation(ShapeNetTextDatasetBase):
+    """Validation split of ShapeNet SDF + text dataset."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault('split', 'val')
+        kwargs.setdefault('ucond_p', 0.0)  # no dropout at validation
+        super().__init__(**kwargs)
+
+
+class ShapeNetSDFDataset(Dataset):
+    """
+    Dataset for AE training (SDF only, no text).
+
+    Args:
+        data_root:  path to the data directory containing 'sdf/'
+        split:      'train' or 'val'
+        cat:        category name or 'all'
+        thres:      SDF clamp threshold
+    """
+
+    def __init__(
+        self,
+        data_root: str = 'data/ShapeNet',
+        split: str = 'train',
+        cat: str = 'all',
+        thres: float = 0.2,
+    ):
+        super().__init__()
+        self.data_root = data_root
+        self.split = split
+        self.thres = thres
+
+        if cat == 'all':
+            self.cat_ids = ALL_CATS
+        elif cat in SHAPENET_CAT_IDS:
+            self.cat_ids = [SHAPENET_CAT_IDS[cat]]
+        else:
+            self.cat_ids = [cat]
+
+        self.samples = self._collect_samples()
+
+    def _collect_samples(self):
+        samples = []
+        sdf_root = os.path.join(self.data_root, 'sdf')
+
+        split_file = os.path.join(self.data_root, f'{self.split}_models.json')
+        if os.path.exists(split_file):
+            with open(split_file, 'r') as f:
+                split_ids = set(json.load(f))
+        else:
+            split_ids = None
+
+        for cat_id in self.cat_ids:
+            cat_dir = os.path.join(sdf_root, cat_id)
+            if not os.path.isdir(cat_dir):
+                continue
+
+            for model_id in sorted(os.listdir(cat_dir)):
+                if split_ids is not None and model_id not in split_ids:
+                    continue
+
+                sdf_path = os.path.join(cat_dir, model_id, 'pc_sdf_sample.h5')
+                if not os.path.exists(sdf_path):
+                    for fname in ['sdf.h5', 'model.h5']:
+                        alt = os.path.join(cat_dir, model_id, fname)
+                        if os.path.exists(alt):
+                            sdf_path = alt
+                            break
+                    else:
+                        continue
+
+                samples.append(sdf_path)
+
+        return samples
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        sdf = load_sdf(self.samples[idx])  # (1, 64, 64, 64)
+
+        if self.thres > 0:
+            sdf = torch.clamp(sdf, -self.thres, self.thres)
+            sdf = sdf / self.thres
+
+        return {'sdf': sdf}

--- a/shape_completion.py
+++ b/shape_completion.py
@@ -1,0 +1,280 @@
+"""
+Shape Completion inference script for Diffusion-SDF.
+
+Given a partial/incomplete SDF and a text prompt, this script completes
+the missing regions using the trained Voxelized Diffusion model.
+
+Usage:
+    python shape_completion.py \\
+        --input_sdf path/to/partial.h5 \\
+        --prompt "a wooden chair" \\
+        --mask_axis z --mask_ratio 0.5
+
+    # Mask with a custom threshold on SDF values:
+    python shape_completion.py \\
+        --input_sdf path/to/shape.h5 \\
+        --prompt "a dining table" \\
+        --mask_type threshold --mask_value 0.0
+
+Arguments:
+    --input_sdf:    Path to h5 file containing the partial SDF (float32, 64³).
+                    If not provided, a random noise shape is used as a demo.
+    --prompt:       Text description of the complete shape.
+    --mask_axis:    Axis to cut ('x', 'y', 'z').
+    --mask_ratio:   Fraction of the volume to mask out (0–1).
+    --mask_type:    'half' (axial cut) or 'threshold' (SDF-value based).
+    --mask_value:   SDF threshold for 'threshold' masking.
+    --n_samples:    Number of completions to generate.
+"""
+
+import argparse
+import os
+
+import h5py
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+from pytorch3d.io import IO
+from tqdm import trange
+
+from models.voxdiff.models.diffusion.ddim import DDIMSampler
+from models.voxdiff.util import instantiate_from_config
+from utils.qual_util import save_mesh_as_gif
+from utils.util_3d import init_mesh_renderer, sdf_to_mesh, read_sdf
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def load_sdf(path: str, thres: float = 0.2) -> torch.Tensor:
+    """Load and normalise an SDF from an h5 file. Returns (1,1,64,64,64)."""
+    with h5py.File(path, 'r') as f:
+        if 'pc_sdf_sample' in f:
+            sdf = f['pc_sdf_sample'][:].astype(np.float32)
+        elif 'sdf' in f:
+            sdf = f['sdf'][:].astype(np.float32)
+        else:
+            key = list(f.keys())[0]
+            sdf = f[key][:].astype(np.float32)
+    sdf = torch.from_numpy(sdf).view(1, 1, 64, 64, 64)
+    sdf = torch.clamp(sdf, -thres, thres) / thres
+    return sdf
+
+
+def make_axial_mask(sdf_shape, axis: str, ratio: float, device) -> torch.Tensor:
+    """
+    Create a binary mask for an axial cut.
+
+    Mask = 1 → keep this voxel (known region).
+    Mask = 0 → this region is unknown / to be completed.
+
+    Args:
+        sdf_shape:  (B, C, D, H, W)
+        axis:       'x', 'y', or 'z'
+        ratio:      fraction of the axis to mask (0.5 = mask the second half)
+        device:     torch device
+
+    Returns:
+        sdf_mask:  (B, 1, D, H, W) float, 1=known 0=unknown
+    """
+    B, C, D, H, W = sdf_shape
+    axis_map = {'x': 2, 'y': 3, 'z': 4}
+    dim = axis_map[axis]
+    sizes = [D, H, W]
+    split = int(sizes[dim - 2] * (1.0 - ratio))
+
+    mask = torch.ones(B, 1, D, H, W, device=device)
+    slices = [slice(None)] * 5
+    slices[dim] = slice(split, None)
+    mask[tuple(slices)] = 0.0
+    return mask
+
+
+def make_threshold_mask(sdf: torch.Tensor, threshold: float = 0.0) -> torch.Tensor:
+    """
+    Mark voxels with SDF < threshold as 'known' (surface / interior) and
+    voxels with SDF >= threshold as 'unknown' (to be completed).
+
+    Returns mask (B, 1, D, H, W) float.
+    """
+    mask = (sdf < threshold).float()
+    return mask
+
+
+def sdf_mask_to_latent_mask(sdf_mask: torch.Tensor, latent_size: int = 8) -> torch.Tensor:
+    """
+    Downsample a 64³ SDF mask to the latent space size (default 8³) via max-pooling.
+
+    Any latent voxel that overlaps with an unknown SDF voxel is set to unknown.
+    sdf_mask: (B, 1, 64, 64, 64) ∈ {0, 1}
+    Returns: (B, 1, latent_size, latent_size, latent_size) ∈ {0, 1}
+    """
+    scale = sdf_mask.shape[-1] // latent_size
+    # Use avg pooling; threshold at 1.0 so any partial unknown voxel → unknown
+    pooled = torch.nn.functional.avg_pool3d(
+        sdf_mask.float(),
+        kernel_size=scale,
+        stride=scale,
+    )
+    # If avg < 1.0, at least one SDF voxel was unknown → latent unknown
+    latent_mask = (pooled >= 1.0).float()
+    return latent_mask
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Diffusion-SDF: Shape Completion')
+    parser.add_argument('--input_sdf', type=str, default='',
+                        help='Path to h5 file with partial SDF. '
+                             'If empty, a demo random shape is used.')
+    parser.add_argument('--prompt', type=str, required=True,
+                        help='Text description of the target shape.')
+    parser.add_argument('--out_path', type=str, default='outputs/shape_completion',
+                        help='Output directory.')
+    parser.add_argument('--config_path', type=str,
+                        default='configs/voxdiff-uinu.yaml')
+    parser.add_argument('--model_path', type=str,
+                        default='ckpt/voxdiff-uinu.ckpt')
+    parser.add_argument('--n_samples', type=int, default=4,
+                        help='Number of completions to generate.')
+    parser.add_argument('--ddim_steps', type=int, default=50)
+    parser.add_argument('--ddim_eta', type=float, default=0.0)
+    parser.add_argument('--scale', type=float, default=5.0,
+                        help='Classifier-free guidance scale.')
+    parser.add_argument('--thres', type=float, default=0.2,
+                        help='SDF normalisation threshold.')
+
+    # Masking options
+    parser.add_argument('--mask_type', type=str, default='half',
+                        choices=['half', 'threshold'],
+                        help='"half": axial cut; "threshold": SDF-value based.')
+    parser.add_argument('--mask_axis', type=str, default='z',
+                        choices=['x', 'y', 'z'])
+    parser.add_argument('--mask_ratio', type=float, default=0.5,
+                        help='Fraction of the axis to mask (for "half" mode).')
+    parser.add_argument('--mask_value', type=float, default=0.0,
+                        help='SDF threshold for "threshold" masking.')
+    parser.add_argument('--save_obj', action='store_true',
+                        help='Also save OBJ mesh files.')
+    return parser.parse_args()
+
+
+def main():
+    opt = parse_args()
+
+    # ── Load model ──────────────────────────────────────────────────────────
+    config = OmegaConf.load(opt.config_path)
+    model = instantiate_from_config(config.model)
+    ckpt = torch.load(opt.model_path, map_location='cpu')
+    model.load_state_dict(ckpt['state_dict'], strict=False)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = model.to(device)
+    model.eval()
+
+    dist, elev, azim = 1.7, 20, 20
+    renderer = init_mesh_renderer(image_size=256, dist=dist, elev=elev, azim=azim, device=device)
+
+    sampler = DDIMSampler(model)
+    os.makedirs(opt.out_path, exist_ok=True)
+
+    # ── Load / create partial SDF ─────────────────────────────────────────
+    if opt.input_sdf and os.path.exists(opt.input_sdf):
+        sdf = load_sdf(opt.input_sdf, thres=opt.thres)  # (1, 1, 64, 64, 64)
+        print(f'[*] Loaded partial SDF from {opt.input_sdf}')
+    else:
+        print('[*] No input SDF provided; using a random SDF as demo.')
+        sdf = torch.randn(1, 1, 64, 64, 64) * 0.1  # near-flat surface
+
+    sdf = sdf.to(device)
+
+    # ── Build mask ────────────────────────────────────────────────────────
+    if opt.mask_type == 'half':
+        sdf_mask = make_axial_mask(
+            sdf.shape, axis=opt.mask_axis, ratio=opt.mask_ratio, device=device
+        )  # (1, 1, 64, 64, 64)
+    else:
+        sdf_mask = make_threshold_mask(sdf, threshold=opt.mask_value).to(device)
+
+    # The masked SDF (only known regions)
+    partial_sdf = sdf * sdf_mask
+
+    # ── Encode the known region into latent space ─────────────────────────
+    with torch.no_grad():
+        with model.ema_scope():
+            # Encode the (full) partial SDF
+            posterior = model.first_stage_model.encode_whole(
+                partial_sdf.expand(opt.n_samples, -1, -1, -1, -1)
+            )
+            x0_latent = model.get_first_stage_encoding(posterior)
+            # x0_latent: (n_samples, 8, 8, 8, 8)
+
+            # Build matching latent mask
+            latent_mask = sdf_mask_to_latent_mask(
+                sdf_mask.expand(opt.n_samples, -1, -1, -1, -1),
+                latent_size=x0_latent.shape[-1],
+            )  # (n_samples, 1, 8, 8, 8)
+            # Expand to match latent channels
+            latent_mask = latent_mask.expand_as(x0_latent)  # (n_samples, 8, 8, 8, 8)
+
+            # ── Text conditioning ─────────────────────────────────────────
+            prompts = opt.n_samples * [opt.prompt]
+            c = model.get_learned_conditioning(prompts)
+
+            uc = None
+            if opt.scale != 1.0:
+                uc = model.get_learned_conditioning(opt.n_samples * [''])
+
+            # ── DDIM sampling with mask ───────────────────────────────────
+            shape = list(x0_latent.shape[1:])  # [8, 8, 8, 8]
+
+            samples_ddim, _ = sampler.sample(
+                S=opt.ddim_steps,
+                conditioning=c,
+                batch_size=opt.n_samples,
+                shape=shape,
+                verbose=False,
+                unconditional_guidance_scale=opt.scale,
+                unconditional_conditioning=uc,
+                eta=opt.ddim_eta,
+                mask=latent_mask,          # 1 = known (lock to x0), 0 = generate
+                x0=x0_latent,             # the encoded known latent
+            )
+
+            # Decode completed latent → SDF
+            completed_sdf = model.decode_first_stage(samples_ddim)
+            # completed_sdf: (n_samples, 1, 64, 64, 64)
+
+    # ── Save results ──────────────────────────────────────────────────────
+    tag = opt.prompt.replace(' ', '-')
+    out_dir = os.path.join(opt.out_path, tag)
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Also save the partial input for visual comparison
+    gen_mesh = sdf_to_mesh(completed_sdf)
+    gif_path = os.path.join(out_dir, f'completion_{tag}.gif')
+    save_mesh_as_gif(renderer, gen_mesh, nrow=2, out_name=gif_path)
+    print(f'[*] Saved GIF: {gif_path}')
+
+    if opt.save_obj and gen_mesh is not None:
+        for k, mesh in enumerate(gen_mesh):
+            obj_path = os.path.join(out_dir, f'completion_{tag}_{k}.obj')
+            IO().save_mesh(mesh, obj_path)
+            print(f'[*] Saved OBJ: {obj_path}')
+
+    # Also render the partial input
+    partial_mesh = sdf_to_mesh(partial_sdf)
+    if partial_mesh is not None:
+        partial_gif = os.path.join(out_dir, 'partial_input.gif')
+        save_mesh_as_gif(renderer, partial_mesh, nrow=1, out_name=partial_gif)
+        print(f'[*] Saved partial input GIF: {partial_gif}')
+
+    print('[*] Shape completion done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/shape_manipulation.py
+++ b/shape_manipulation.py
@@ -1,0 +1,264 @@
+"""
+Shape Manipulation inference script for Diffusion-SDF.
+
+Given an existing 3D shape (SDF) and a text prompt, this script modifies
+the shape according to the text description using the SDEdit approach:
+  1. Encode the input shape to the latent space.
+  2. Add Gaussian noise up to a chosen timestep (controls how much to change).
+  3. Denoise with the new text prompt to guide the manipulation.
+
+Usage:
+    # Moderate manipulation (t=500 / 1000):
+    python shape_manipulation.py \\
+        --input_sdf path/to/shape.h5 \\
+        --prompt "a chair with a cushion" \\
+        --strength 0.5
+
+    # Strong manipulation (t=750 / 1000 – more creative freedom):
+    python shape_manipulation.py \\
+        --input_sdf path/to/shape.h5 \\
+        --prompt "a modern minimalist chair" \\
+        --strength 0.75
+
+Arguments:
+    --input_sdf:  Path to h5 file with the original SDF (float32, 64³).
+    --prompt:     Text description for the target modification.
+    --strength:   Noise strength in [0, 1]. Higher = more modification.
+                  0.0 → identity (no change), 1.0 → full generation.
+    --n_samples:  Number of manipulated variants to generate.
+"""
+
+import argparse
+import os
+
+import h5py
+import numpy as np
+import torch
+from omegaconf import OmegaConf
+from pytorch3d.io import IO
+from tqdm import tqdm
+
+from models.voxdiff.models.diffusion.ddim import DDIMSampler
+from models.voxdiff.util import instantiate_from_config
+from utils.qual_util import save_mesh_as_gif
+from utils.util_3d import init_mesh_renderer, sdf_to_mesh
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def load_sdf(path: str, thres: float = 0.2) -> torch.Tensor:
+    """Load and normalise an SDF from an h5 file. Returns (1,1,64,64,64)."""
+    with h5py.File(path, 'r') as f:
+        if 'pc_sdf_sample' in f:
+            sdf = f['pc_sdf_sample'][:].astype(np.float32)
+        elif 'sdf' in f:
+            sdf = f['sdf'][:].astype(np.float32)
+        else:
+            key = list(f.keys())[0]
+            sdf = f[key][:].astype(np.float32)
+    sdf = torch.from_numpy(sdf).view(1, 1, 64, 64, 64)
+    sdf = torch.clamp(sdf, -thres, thres) / thres
+    return sdf
+
+
+@torch.no_grad()
+def sdedit(
+    model,
+    sampler: DDIMSampler,
+    x0_latent: torch.Tensor,
+    conditioning,
+    unconditional_conditioning,
+    strength: float,
+    ddim_steps: int = 50,
+    eta: float = 0.0,
+    scale: float = 5.0,
+) -> torch.Tensor:
+    """
+    SDEdit: noise x0_latent to timestep t = strength * T, then denoise with text.
+
+    Args:
+        model:                   VoxelizedDiffusion model.
+        sampler:                 DDIMSampler instance.
+        x0_latent:               Encoded latent of the original shape (B, C, H, W, D).
+        conditioning:            Text conditioning tensor.
+        unconditional_conditioning: Null conditioning for CFG.
+        strength:                Noise level in [0, 1].
+        ddim_steps:              Total DDIM steps.
+        eta:                     DDIM stochasticity (0 = deterministic).
+        scale:                   CFG scale.
+
+    Returns:
+        Denoised latent tensor of same shape as x0_latent.
+    """
+    device = x0_latent.device
+
+    # Total diffusion steps
+    T = model.num_timesteps  # typically 1000
+
+    # The DDIM schedule
+    sampler.make_schedule(ddim_num_steps=ddim_steps, ddim_discretize='slow_fast',
+                          ddim_eta=eta, verbose=False)
+
+    # Determine the starting timestep for denoising
+    # strength=0.5 → start from step ddim_steps//2 in the DDIM schedule
+    t_start = min(int(strength * ddim_steps), ddim_steps - 1)
+    t_start = max(t_start, 1)
+
+    # Corresponding diffusion timestep
+    t_enc_idx = len(sampler.ddim_timesteps) - t_start
+    t_enc = sampler.ddim_timesteps[t_enc_idx]
+    t_tensor = torch.full((x0_latent.shape[0],), t_enc, device=device, dtype=torch.long)
+
+    # Add noise to the latent at this timestep
+    noise = torch.randn_like(x0_latent)
+    x_noisy = model.q_sample(x_start=x0_latent, t=t_tensor, noise=noise)
+
+    # Run DDIM sampling, starting from the noised latent (not pure Gaussian)
+    shape = list(x0_latent.shape[1:])  # [C, H, W, D]
+
+    # We pass x_noisy as x_T and use only t_start DDIM steps
+    samples, _ = sampler.sample(
+        S=t_start,
+        conditioning=conditioning,
+        batch_size=x0_latent.shape[0],
+        shape=shape,
+        verbose=False,
+        x_T=x_noisy,
+        unconditional_guidance_scale=scale,
+        unconditional_conditioning=unconditional_conditioning,
+        eta=eta,
+    )
+    return samples
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Diffusion-SDF: Shape Manipulation')
+    parser.add_argument('--input_sdf', type=str, default='',
+                        help='Path to h5 file with the original SDF. '
+                             'If empty, a random shape is used as demo.')
+    parser.add_argument('--prompt', type=str, required=True,
+                        help='Text description for the manipulated shape.')
+    parser.add_argument('--out_path', type=str, default='outputs/shape_manipulation',
+                        help='Output directory.')
+    parser.add_argument('--config_path', type=str,
+                        default='configs/voxdiff-uinu.yaml')
+    parser.add_argument('--model_path', type=str,
+                        default='ckpt/voxdiff-uinu.ckpt')
+    parser.add_argument('--n_samples', type=int, default=4,
+                        help='Number of manipulated variants to generate.')
+    parser.add_argument('--strength', type=float, default=0.5,
+                        help='Manipulation strength in [0,1]. '
+                             '0=no change, 1=full generation.')
+    parser.add_argument('--ddim_steps', type=int, default=50)
+    parser.add_argument('--ddim_eta', type=float, default=0.0)
+    parser.add_argument('--scale', type=float, default=5.0,
+                        help='Classifier-free guidance scale.')
+    parser.add_argument('--thres', type=float, default=0.2,
+                        help='SDF normalisation threshold.')
+    parser.add_argument('--save_obj', action='store_true',
+                        help='Also save OBJ mesh files.')
+    return parser.parse_args()
+
+
+def main():
+    opt = parse_args()
+
+    # ── Load model ──────────────────────────────────────────────────────────
+    config = OmegaConf.load(opt.config_path)
+    model = instantiate_from_config(config.model)
+    ckpt = torch.load(opt.model_path, map_location='cpu')
+    model.load_state_dict(ckpt['state_dict'], strict=False)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = model.to(device)
+    model.eval()
+
+    dist, elev, azim = 1.7, 20, 20
+    renderer = init_mesh_renderer(image_size=256, dist=dist, elev=elev, azim=azim, device=device)
+
+    sampler = DDIMSampler(model)
+    os.makedirs(opt.out_path, exist_ok=True)
+
+    # ── Load / create input SDF ───────────────────────────────────────────
+    if opt.input_sdf and os.path.exists(opt.input_sdf):
+        sdf = load_sdf(opt.input_sdf, thres=opt.thres)  # (1, 1, 64, 64, 64)
+        print(f'[*] Loaded input SDF from {opt.input_sdf}')
+    else:
+        print('[*] No input SDF provided; using a random SDF as demo.')
+        sdf = torch.randn(1, 1, 64, 64, 64) * 0.1
+
+    sdf = sdf.to(device)
+
+    # Replicate for batch
+    sdf_batch = sdf.expand(opt.n_samples, -1, -1, -1, -1)  # (n_samples, 1, 64, 64, 64)
+
+    with torch.no_grad():
+        with model.ema_scope():
+            # ── Encode input to latent ─────────────────────────────────────
+            posterior = model.first_stage_model.encode_whole(sdf_batch)
+            x0_latent = model.get_first_stage_encoding(posterior)
+            # x0_latent: (n_samples, 8, 8, 8, 8)
+
+            # ── Text conditioning ─────────────────────────────────────────
+            prompts = opt.n_samples * [opt.prompt]
+            c = model.get_learned_conditioning(prompts)
+
+            uc = None
+            if opt.scale != 1.0:
+                uc = model.get_learned_conditioning(opt.n_samples * [''])
+
+            # ── SDEdit manipulation ───────────────────────────────────────
+            samples_ddim = sdedit(
+                model=model,
+                sampler=sampler,
+                x0_latent=x0_latent,
+                conditioning=c,
+                unconditional_conditioning=uc,
+                strength=opt.strength,
+                ddim_steps=opt.ddim_steps,
+                eta=opt.ddim_eta,
+                scale=opt.scale,
+            )
+            # samples_ddim: (n_samples, 8, 8, 8, 8)
+
+            # ── Decode to SDF ─────────────────────────────────────────────
+            manipulated_sdf = model.decode_first_stage(samples_ddim)
+            # (n_samples, 1, 64, 64, 64)
+
+    # ── Save results ──────────────────────────────────────────────────────
+    tag = opt.prompt.replace(' ', '-')
+    strength_tag = f's{int(opt.strength * 100)}'
+    out_dir = os.path.join(opt.out_path, f'{tag}_{strength_tag}')
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Save the original shape for comparison
+    orig_mesh = sdf_to_mesh(sdf)
+    if orig_mesh is not None:
+        orig_gif = os.path.join(out_dir, 'original.gif')
+        save_mesh_as_gif(renderer, orig_mesh, nrow=1, out_name=orig_gif)
+        print(f'[*] Saved original GIF: {orig_gif}')
+
+    # Save the manipulated shapes
+    gen_mesh = sdf_to_mesh(manipulated_sdf)
+    if gen_mesh is not None:
+        out_gif = os.path.join(out_dir, f'manipulated_{tag}.gif')
+        save_mesh_as_gif(renderer, gen_mesh, nrow=2, out_name=out_gif)
+        print(f'[*] Saved manipulated GIF: {out_gif}')
+
+        if opt.save_obj:
+            for k, mesh in enumerate(gen_mesh):
+                obj_path = os.path.join(out_dir, f'manipulated_{tag}_{k}.obj')
+                IO().save_mesh(mesh, obj_path)
+                print(f'[*] Saved OBJ: {obj_path}')
+
+    print('[*] Shape manipulation done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/train_ae.py
+++ b/train_ae.py
@@ -1,0 +1,417 @@
+"""
+Training script for the SDF Autoencoder (PVQVAE_diff / Diffusion-SDF AE).
+
+This script trains the patch-wise variational autoencoder that encodes
+64³ SDF volumes into a compact 8³ latent space used by the diffusion model.
+
+Usage:
+    python train_ae.py --data_root data/ShapeNet --cat all
+
+    # Resume from epoch N:
+    python train_ae.py --data_root data/ShapeNet --resume ckpt/vae_epoch-120.pth
+                       --start_epoch 121
+
+    # Multi-GPU (DDP):
+    torchrun --nproc_per_node=4 train_ae.py --data_root data/ShapeNet --dist_train
+
+Expected data layout:
+    data/ShapeNet/sdf/<category_id>/<model_id>/pc_sdf_sample.h5
+"""
+
+import argparse
+import os
+import time
+from collections import OrderedDict
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from omegaconf import OmegaConf
+from termcolor import cprint
+from torch.utils.data import DataLoader, random_split
+from torch.utils.data.distributed import DistributedSampler
+from tqdm import tqdm
+
+from models.networks.pvqvae_networks.auto_encoder import PVQVAE_diff
+from models.voxdiff.modules.losses.contperceptual import LPIPSWithDiscriminator
+from models.voxdiff.util import instantiate_from_config
+from models.voxdiff.data.snet import ShapeNetSDFDataset
+from utils.util_3d import init_mesh_renderer, render_sdf
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Argument parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Train SDF Autoencoder')
+
+    # Data
+    parser.add_argument('--data_root', type=str, default='data/ShapeNet',
+                        help='Root directory for ShapeNet SDF data')
+    parser.add_argument('--cat', type=str, default='all',
+                        help='ShapeNet category (e.g. "chair") or "all"')
+    parser.add_argument('--thres', type=float, default=0.2,
+                        help='SDF clamp threshold')
+
+    # Model config
+    parser.add_argument('--vq_cfg', type=str, default='configs/voxdiff-uinu.yaml',
+                        help='Path to config yaml containing first_stage_config')
+
+    # Training
+    parser.add_argument('--epochs', type=int, default=200,
+                        help='Total number of training epochs')
+    parser.add_argument('--batch_size', type=int, default=16,
+                        help='Batch size per GPU')
+    parser.add_argument('--lr', type=float, default=4.5e-6,
+                        help='Base learning rate')
+    parser.add_argument('--num_workers', type=int, default=4,
+                        help='DataLoader workers per GPU')
+    parser.add_argument('--val_split', type=float, default=0.05,
+                        help='Fraction of data to use for validation')
+
+    # Checkpointing
+    parser.add_argument('--save_dir', type=str, default='ckpt',
+                        help='Directory to save checkpoints')
+    parser.add_argument('--save_freq', type=int, default=10,
+                        help='Save checkpoint every N epochs')
+    parser.add_argument('--resume', type=str, default='',
+                        help='Path to checkpoint to resume from')
+    parser.add_argument('--start_epoch', type=int, default=0,
+                        help='Starting epoch number (when resuming)')
+
+    # Loss
+    parser.add_argument('--kl_weight', type=float, default=1e-6,
+                        help='Weight for KL divergence loss')
+    parser.add_argument('--disc_start', type=int, default=50001,
+                        help='Global step to start discriminator training')
+
+    # Logging
+    parser.add_argument('--log_freq', type=int, default=100,
+                        help='Print log every N steps')
+    parser.add_argument('--vis_freq', type=int, default=500,
+                        help='Visualise reconstructions every N steps')
+
+    # Distributed
+    parser.add_argument('--dist_train', action='store_true',
+                        help='Enable distributed data-parallel training')
+    parser.add_argument('--local_rank', type=int, default=0,
+                        help='Local rank (set automatically by torchrun)')
+
+    return parser.parse_args()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def is_main_process(args):
+    return (not args.dist_train) or (args.local_rank == 0)
+
+
+def print_main(args, msg, color='white'):
+    if is_main_process(args):
+        cprint(msg, color)
+
+
+def save_checkpoint(args, model, optimizer, epoch, global_step, label=None):
+    if not is_main_process(args):
+        return
+    os.makedirs(args.save_dir, exist_ok=True)
+    label = label or f'epoch-{epoch}'
+    path = os.path.join(args.save_dir, f'vae_{label}.pth')
+    state_dict = model.module.state_dict() if args.dist_train else model.state_dict()
+    torch.save({
+        'model': state_dict,
+        'optimizer': optimizer.state_dict(),
+        'epoch': epoch,
+        'global_step': global_step,
+    }, path)
+    cprint(f'[*] Saved checkpoint: {path}', 'green')
+
+
+def load_checkpoint(args, model, optimizer=None):
+    if not args.resume:
+        return model, optimizer, args.start_epoch, 0
+    if not os.path.exists(args.resume):
+        cprint(f'[!] Checkpoint not found: {args.resume}', 'red')
+        return model, optimizer, args.start_epoch, 0
+
+    ckpt = torch.load(args.resume, map_location='cpu')
+
+    # Support both bare state_dict and wrapped {'model': ...}
+    state_dict = ckpt.get('model', ckpt)
+    model.load_state_dict(state_dict, strict=False)
+    cprint(f'[*] Loaded model weights from {args.resume}', 'blue')
+
+    if optimizer is not None and 'optimizer' in ckpt:
+        optimizer.load_state_dict(ckpt['optimizer'])
+
+    epoch = ckpt.get('epoch', args.start_epoch)
+    step = ckpt.get('global_step', 0)
+    return model, optimizer, epoch, step
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Patch helpers  (mirror pvqvae_model_diff.py)
+# ─────────────────────────────────────────────────────────────────────────────
+
+from einops import rearrange
+
+
+def unfold_to_cubes(x, cube_size=8, stride=8):
+    """x: (B,1,64,64,64) → (B*P, 1, 8, 8, 8)"""
+    x_cubes = x.unfold(2, cube_size, stride).unfold(3, cube_size, stride).unfold(4, cube_size, stride)
+    x_cubes = rearrange(x_cubes, 'b c p1 p2 p3 d h w -> b c (p1 p2 p3) d h w')
+    x_cubes = rearrange(x_cubes, 'b c p d h w -> (b p) c d h w')
+    return x_cubes
+
+
+def fold_to_voxels(x_cubes, batch_size, ncubes_per_dim):
+    """(B*P, c, d, h, w) → (B, c, D, H, W)"""
+    x = rearrange(x_cubes, '(b p) c d h w -> b p c d h w', b=batch_size)
+    x = rearrange(x, 'b (p1 p2 p3) c d h w -> b c (p1 d) (p2 h) (p3 w)',
+                  p1=ncubes_per_dim, p2=ncubes_per_dim, p3=ncubes_per_dim)
+    return x
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main training function
+# ─────────────────────────────────────────────────────────────────────────────
+
+def main():
+    args = get_args()
+
+    # ── Distributed setup ───────────────────────────────────────────────────
+    if args.dist_train:
+        dist.init_process_group(backend='nccl')
+        torch.cuda.set_device(args.local_rank)
+        device = torch.device('cuda', args.local_rank)
+    else:
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    print_main(args, f'[*] Using device: {device}', 'cyan')
+
+    # ── Load model config ───────────────────────────────────────────────────
+    config = OmegaConf.load(args.vq_cfg)
+    fs_cfg = config.model.params.first_stage_config.params
+    ddconfig = fs_cfg.ddconfig
+    n_embed = fs_cfg.n_embed
+    embed_dim = fs_cfg.embed_dim
+
+    # Patch architecture parameters
+    n_down = len(ddconfig.ch_mult) - 1
+    cube_size = 2 ** n_down          # 8 for 4-level encoder
+    ncubes_per_dim = ddconfig.resolution // cube_size  # 8 = 64/8
+
+    # ── Build model ─────────────────────────────────────────────────────────
+    model = PVQVAE_diff(ddconfig, n_embed, embed_dim)
+    model.to(device)
+
+    # ── Loss ─────────────────────────────────────────────────────────────────
+    loss_fn = LPIPSWithDiscriminator(
+        disc_start=args.disc_start,
+        kl_weight=args.kl_weight,
+        disc_weight=0.0,        # no GAN loss for 3-D (2D discriminator not applicable)
+        perceptual_weight=0.0,  # no 2-D perceptual loss for 3-D SDF
+    ).to(device)
+
+    # ── Optimiser ───────────────────────────────────────────────────────────
+    optimizer = torch.optim.Adam(
+        list(model.parameters()),
+        lr=args.lr,
+        betas=(0.5, 0.9),
+    )
+
+    # ── Resume ──────────────────────────────────────────────────────────────
+    model, optimizer, start_epoch, global_step = load_checkpoint(args, model, optimizer)
+
+    # ── Distributed wrapping ─────────────────────────────────────────────────
+    if args.dist_train:
+        model = nn.parallel.DistributedDataParallel(
+            model,
+            device_ids=[args.local_rank],
+            output_device=args.local_rank,
+            find_unused_parameters=True,
+        )
+
+    # ── Dataset ──────────────────────────────────────────────────────────────
+    full_dataset = ShapeNetSDFDataset(
+        data_root=args.data_root,
+        split='train',
+        cat=args.cat,
+        thres=args.thres,
+    )
+    if len(full_dataset) == 0:
+        cprint('[!] Dataset is empty. Check --data_root path and data structure.', 'red')
+        return
+
+    n_val = max(1, int(len(full_dataset) * args.val_split))
+    n_train = len(full_dataset) - n_val
+    train_set, val_set = random_split(
+        full_dataset, [n_train, n_val],
+        generator=torch.Generator().manual_seed(42),
+    )
+    print_main(args, f'[*] Dataset: {n_train} train / {n_val} val', 'cyan')
+
+    if args.dist_train:
+        train_sampler = DistributedSampler(train_set)
+        val_sampler = DistributedSampler(val_set, shuffle=False)
+    else:
+        train_sampler = val_sampler = None
+
+    train_loader = DataLoader(
+        train_set,
+        batch_size=args.batch_size,
+        shuffle=(train_sampler is None),
+        sampler=train_sampler,
+        num_workers=args.num_workers,
+        pin_memory=True,
+        drop_last=True,
+    )
+    val_loader = DataLoader(
+        val_set,
+        batch_size=args.batch_size,
+        shuffle=False,
+        sampler=val_sampler,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
+
+    # ── Scheduler ─────────────────────────────────────────────────────────
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=30, gamma=0.5)
+    for _ in range(start_epoch):
+        scheduler.step()
+
+    # ── Renderer (main process only) ──────────────────────────────────────
+    renderer = None
+    if is_main_process(args):
+        try:
+            renderer = init_mesh_renderer(image_size=256, dist=1.7, elev=20, azim=20, device=device)
+        except Exception:
+            renderer = None
+
+    # ── Training loop ─────────────────────────────────────────────────────
+    print_main(args, '[*] Starting AE training', 'green')
+    best_val_loss = float('inf')
+
+    for epoch in range(start_epoch, args.epochs):
+        model.train()
+        if args.dist_train:
+            train_sampler.set_epoch(epoch)
+
+        epoch_losses = []
+        t0 = time.time()
+
+        for step, batch in enumerate(train_loader):
+            x = batch['sdf'].to(device)               # (B, 1, 64, 64, 64)
+            cur_bs = x.shape[0]
+
+            # Unfold into patches
+            x_cubes = unfold_to_cubes(x, cube_size, cube_size)  # (B*P, 1, 8, 8, 8)
+
+            # Forward
+            posterior = model.encode(x_cubes) if not args.dist_train \
+                else model.module.encode(x_cubes)
+            z = posterior.sample()
+            z_voxel = fold_to_voxels(z, batch_size=cur_bs, ncubes_per_dim=ncubes_per_dim)
+            dec = (model.decode if not args.dist_train else model.module.decode)(z_voxel)
+
+            # Loss (optimizer_idx=0 → AE loss)
+            last_layer = (model.get_last_layer if not args.dist_train
+                          else model.module.get_last_layer)()
+            aeloss, log_dict = loss_fn(
+                inputs=x,
+                reconstructions=dec,
+                posteriors=posterior,
+                optimizer_idx=0,
+                global_step=global_step,
+                last_layer=last_layer,
+                split='train',
+            )
+
+            # Backward
+            optimizer.zero_grad(set_to_none=True)
+            aeloss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+
+            global_step += 1
+            epoch_losses.append(aeloss.item())
+
+            if is_main_process(args) and step % args.log_freq == 0:
+                rec_loss = log_dict.get('train/rec_loss', torch.tensor(0.0))
+                kl_loss = log_dict.get('train/kl_loss', torch.tensor(0.0))
+                nll_loss = log_dict.get('train/nll_loss', torch.tensor(0.0))
+                elapsed = time.time() - t0
+                print(f'Epoch [{epoch+1}/{args.epochs}] Step [{step}/{len(train_loader)}] '
+                      f'Loss: {aeloss.item():.4f} '
+                      f'(rec={_to_scalar(rec_loss):.4f}, '
+                      f'kl={_to_scalar(kl_loss):.6f}, '
+                      f'nll={_to_scalar(nll_loss):.4f}) '
+                      f'| {elapsed:.1f}s elapsed')
+
+        scheduler.step()
+
+        # ── Validation ─────────────────────────────────────────────────────
+        val_loss = validate(args, model, val_loader, loss_fn, device, cube_size, ncubes_per_dim, global_step)
+        avg_train = sum(epoch_losses) / max(len(epoch_losses), 1)
+        print_main(args, f'[Epoch {epoch+1}] train_loss={avg_train:.4f}  val_loss={val_loss:.4f}', 'yellow')
+
+        # ── Checkpoint ─────────────────────────────────────────────────────
+        if is_main_process(args):
+            if val_loss < best_val_loss:
+                best_val_loss = val_loss
+                save_checkpoint(args, model, optimizer, epoch + 1, global_step, label='best')
+
+            if (epoch + 1) % args.save_freq == 0:
+                save_checkpoint(args, model, optimizer, epoch + 1, global_step,
+                                label=f'epoch-{epoch+1}')
+
+    # ── Final checkpoint ─────────────────────────────────────────────────
+    save_checkpoint(args, model, optimizer, args.epochs, global_step, label='final')
+    print_main(args, '[*] Training complete.', 'green')
+
+    if args.dist_train:
+        dist.destroy_process_group()
+
+
+def _to_scalar(x):
+    if isinstance(x, torch.Tensor):
+        return x.item()
+    return float(x)
+
+
+@torch.no_grad()
+def validate(args, model, val_loader, loss_fn, device, cube_size, ncubes_per_dim, global_step):
+    model.eval()
+    losses = []
+    for batch in val_loader:
+        x = batch['sdf'].to(device)
+        cur_bs = x.shape[0]
+        x_cubes = unfold_to_cubes(x, cube_size, cube_size)
+
+        posterior = (model.encode if not args.dist_train else model.module.encode)(x_cubes)
+        z = posterior.mode()  # deterministic at validation
+        z_voxel = fold_to_voxels(z, batch_size=cur_bs, ncubes_per_dim=ncubes_per_dim)
+        dec = (model.decode if not args.dist_train else model.module.decode)(z_voxel)
+
+        last_layer = (model.get_last_layer if not args.dist_train
+                      else model.module.get_last_layer)()
+        loss, _ = loss_fn(
+            inputs=x,
+            reconstructions=dec,
+            posteriors=posterior,
+            optimizer_idx=0,
+            global_step=global_step,
+            last_layer=last_layer,
+            split='val',
+        )
+        losses.append(loss.item())
+
+    model.train()
+    return sum(losses) / max(len(losses), 1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- models/voxdiff/data/snet.py: ShapeNet SDF+text dataset classes (ShapeNetTextDatasetTrain, ShapeNetTextDatasetValidation, ShapeNetSDFDataset) used by both AE training and diffusion model training.

- train_ae.py: Training script for the SDF variational autoencoder (PVQVAE_diff). Supports single-GPU and multi-GPU DDP, checkpoint saving/resuming, and configurable loss weights.

- main.py: PyTorch Lightning training script for the Voxelized Diffusion model. Implements DataModuleFromConfig (referenced in configs), logging callbacks, checkpoint management, and multi-GPU support.

- shape_completion.py: Inference script for text-conditioned shape completion. Encodes a partial SDF, builds a binary latent mask for unknown regions, and runs DDIM sampling with mask+x0 to complete the missing geometry while preserving known regions.

- shape_manipulation.py: Inference script for text-guided shape manipulation using SDEdit. Encodes an existing shape, adds noise to a chosen timestep (controlled by --strength), and denoises with the target text prompt.